### PR TITLE
Fixing Windows post-link problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: objective-c
 
 env:
   matrix:
-
+    
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
@@ -29,12 +29,11 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --add channels defaults
       conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-
+      
 
 script:
   - conda build ./recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ install:
 
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
+    - cmd: conda config --add channels defaults
     - cmd: conda config --add channels conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - "%CMD_IN_ENV% conda build -c defaults -d conda-forge recipe --quiet"
 deploy_script:
 
     - 'python ci_support\upload_or_check_non_existence.py .\recipe conda-forge --channel=main'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,8 +61,6 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
-    # (Temporary) hack for working with conda 4.1
-    - cmd: conda config --add channels defaults
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,9 @@ install:
 
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels defaults
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --get channels
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build -c defaults -d conda-forge recipe --quiet"
+    - "%CMD_IN_ENV% conda build -c defaults -c conda-forge recipe --quiet"
 deploy_script:
 
     - 'python ci_support\upload_or_check_non_existence.py .\recipe conda-forge --channel=main'

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,1 +1,1 @@
-"%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+"%PREFIX%\python.exe" -d -m nb_conda_kernels.install --enable --prefix="%PREFIX%"

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,3 @@
-1>>"%PREFIX%\.messages.txt" 2>&1 (
+(
   "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
-)
+) >>"%PREFIX%\.messages.txt" 2>&1 

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,1 +1,3 @@
-"%PREFIX%\python.exe" -d -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+(
+  "%PREFIX%\python.exe" -d -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,3 @@
-@echo off
 1>>"%PREFIX%\.messages.txt" 2>&1 (
   "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
 )

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,1 @@
-(
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
-) >>"%PREFIX%\.messages.txt" 2>&1 
+"%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,3 @@
-1>>"%PREFIX%\.messages.txt" 2>&1 (
+(
   "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
-)
+) >>"%PREFIX%\.messages.txt" 2>&1 

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,4 +1,3 @@
-@echo off
 1>>"%PREFIX%\.messages.txt" 2>&1 (
   "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
 )


### PR DESCRIPTION
Removing `@echo off` in win scripts, as the errors apparently don't make it to `.messages.txt`. Or something.