### PR TITLE
Disable echo in [un]link batch scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 6cdc08c3337c06e5cffacce150dbd10f87334489768e4c8804e045d28f65532a
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,5 @@
+@echo off
+
 (
   "%PREFIX%\python.exe" -d -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
 ) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,5 @@
+@echo off
+
 (
   "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
 ) >>"%PREFIX%\.messages.txt" 2>&1 


### PR DESCRIPTION
We've discovered that there is some noise from the commands run in the batch files due to these [un]link batch scripts. It was found through [discussion]( https://github.com/conda-forge/ipyparallel-feedstock/pull/6#issuecomment-234967309 ) that this change would solve that issue.