### PR TITLE
Update to 2.1.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,4 @@
+%PYTHON% setup.py install --single-version-externally-managed --record=record.txt
+mkdir Scripts
+copy %SRC_DIR%\conda-recipe\post-link.bat Scripts\.nb_conda_kernels-post-link.bat
+copy %SRC_DIR%\conda-recipe\pre-unlink.bat Scripts\.nb_conda_kernels-pre-unlink.bat

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,7 @@
+python setup.py install --single-version-externally-managed --record=record.txt
+mkdir -p bin
+POST_LINK=bin/.nb_conda_kernels-post-link.sh
+PRE_UNLINK=bin/.nb_conda_kernels-pre-unlink.sh
+cp $SRC_DIR/conda-recipe/post-link.sh $POST_LINK
+cp $SRC_DIR/conda-recipe/pre-unlink.sh $PRE_UNLINK
+chmod +x $POST_LINK $PRE_UNLINK

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - bollwyvl
     - ocefpaf
     - damianavila
     - mcg1969

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 {% set gh_org = "Anaconda-Platform" %}
 {% set gh_repo = "nb_conda_kernels" %}
 
@@ -9,12 +9,10 @@ package:
 source:
   fn: {{ gh_repo }}-{{ version }}.tar.gz
   url: https://github.com/{{ gh_org }}/{{ gh_repo }}/archive/{{ version }}.tar.gz
-  sha256: 4e333eadeb42b00ae7c50564cb619ce03cbf11cc0ed3747154d32aa1f0c279ed
+  sha256: 71a3cf565eb1183ab0992d6364907c9bf063cdd3d7b4c287b3c44fa6dce9c69f
 
 build:
   number: 0
-  script:
-    - python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
@@ -39,3 +37,4 @@ extra:
     - bollwyvl
     - ocefpaf
     - damianavila
+    - mcg1969

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,0 @@
-@echo off
-(
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
-) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,3 +1,0 @@
-{
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix="${PREFIX}"
-} >>"$PREFIX/.messages.txt" 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,4 +1,0 @@
-@echo off
-(
-  "%PREFIX%\python.exe" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
-) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,3 +1,0 @@
-{
-  "${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix="${PREFIX}"
-} >>"$PREFIX/.messages.txt" 2>&1

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-fontconfig


### PR DESCRIPTION
Note: the pre- and post-link scripts are now hosted and controlled in the [source repo](https://github.com/Anaconda-Platform/nb_conda_kernels/tree/master/conda-recipe).

@bollwyvl, do you still want to be listed as a maintainer here? I can remove you if you like.