### PR TITLE
Remove r-ikernel from run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -19,7 +19,6 @@ requirements:
   run:
     - python >=3.8,<3.12
     - notebook
-    - r-irkernel
     - requests
     - psutil
     - pywin32  # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

For context: https://github.com/conda-forge/nb_conda_kernels-feedstock/pull/56#discussion_r1576519099.

I might miss good reasons why `r-ikernel` has been added as a run requirement so please ignore / close this PR if that's the case.